### PR TITLE
Init: disconnect from database on exit

### DIFF
--- a/CBM_defaults.R
+++ b/CBM_defaults.R
@@ -183,10 +183,6 @@ sim$species_tr <- species_tr[locale_id <= 1,]
 
 .inputObjects <- function(sim) {
 
-  #cacheTags <- c(currentModule(sim), "function:.inputObjects") ## uncomment this if Cache is being used
-  dPath <- asPath(getOption("reproducible.destinationPath", dataPath(sim)), 1)
-  message(currentModule(sim), ": using dataPath '", dPath, "'.")
-
   # ! ----- EDIT BELOW ----- ! #
 
   if (!suppliedElsewhere(sim$dbPath)) {

--- a/CBM_defaults.R
+++ b/CBM_defaults.R
@@ -74,8 +74,11 @@ doEvent.CBM_defaults <- function(sim, eventTime, eventType, debug = FALSE) {
 ### template initialization
 Init <- function(sim) {
   # # ! ----- EDIT BELOW ----- ! #
-  #get database
+
+  # Connect to database
   archiveIndex <- dbConnect(dbDriver("SQLite"), sim$dbPath)
+  on.exit(dbDisconnect(archiveIndex))
+
   # dbListTables(archiveIndex)
   # [1] "admin_boundary"                       "admin_boundary_tr"
   # [3] "afforestation_initial_pool"           "afforestation_pre_type"

--- a/CBM_defaults.R
+++ b/CBM_defaults.R
@@ -13,16 +13,7 @@ defineModule(sim, list(
   documentation = list("README.txt", "CBM_defaults.Rmd"),
   reqdPkgs = list("RSQLite", "data.table", "withr"),
 
-  parameters = bindrows( ##TODO: these are all default SpaDES parameters, not sure if all are needed here
-    #defineParameter("paramName", "paramClass", value, min, max, "parameter description"),
-    defineParameter(".plotInitialTime", "numeric", start(sim), NA, NA,
-                    "Describes the simulation time at which the first plot event should occur."),
-    defineParameter(".plotInterval", "numeric", NA, NA, NA,
-                    "Describes the simulation time interval between plot events."),
-    defineParameter(".saveInitialTime", "numeric", NA, NA, NA,
-                    "Describes the simulation time at which the first save event should occur."),
-    defineParameter(".saveInterval", "numeric", NA, NA, NA,
-                    "This describes the simulation time interval between save events."),
+  parameters = bindrows(
     defineParameter(".useCache", "logical", FALSE, NA, NA,
                     "Should caching of events or module be used?") ##TODO: keep if caching
   ),
@@ -48,26 +39,9 @@ doEvent.CBM_defaults <- function(sim, eventTime, eventType, debug = FALSE) {
   switch(
     eventType,
     init = {
-      ### check for more detailed object dependencies:
-      ### (use `checkObject` or similar)
-
-      # do stuff for this event
       sim <- Init(sim)
-
-      # schedule future event(s)
-      sim <- scheduleEvent(sim, P(sim)$.plotInitialTime, "CBM_defaults", "plot")
-      sim <- scheduleEvent(sim, P(sim)$.saveInitialTime, "CBM_defaults", "save")
     },
-    # plot = {
-    #
-    # },
-    # save = {
-    #
-    # },
-    warning(paste("Undefined event type: '", current(sim)[1, "eventType", with = FALSE],
-      "' in module '", current(sim)[1, "moduleName", with = FALSE], "'",
-      sep = ""
-    ))
+    warning(noEventWarning(sim))
   )
   return(invisible(sim))
 }


### PR DESCRIPTION
Fixes this warning that kept coming through in our tests: `call dbDisconnect() when finished working with a connection`

`spadesCBM` test passing, with the warning no longer coming through:

```
  # Set custom module locations
  options("spadesCBM.test.module.CBM_core"        = "PredictiveEcology/CBM_core@development")
  options("spadesCBM.test.module.CBM_defaults"    = "suz-estella/CBM_defaults@development")
  options("spadesCBM.test.module.CBM_vol2biomass" = "PredictiveEcology/CBM_vol2biomass@development")
  options("spadesCBM.test.module.CBM_dataPrep_SK" = "PredictiveEcology/CBM_dataPrep_SK@development")

  # Skip recreating the Python virtual environment
  options("spadesCBM.test.virtualEnv" = FALSE)

  # Suppress warnings from calls to setupProject, simInit, and spades
  options("spadesCBM.test.suppressWarnings" = TRUE)

  # Set custom input data location
  options("reproducible.inputPaths" = NULL)

  ## Run 1998-2000 with AOI
  testthat::test_file("tests/testthat/test-AOI_t1-1998-2000.R")
```