### PR TITLE
CBM DB downloaded directly using download.file

### DIFF
--- a/CBM_defaults.R
+++ b/CBM_defaults.R
@@ -212,12 +212,16 @@ sim$species_tr <- species_tr[locale_id <= 1,]
 
     }else{
 
-      sim$dbPath <- prepInputs(
+      sim$dbPath <- file.path(inputPath(sim), "cbm_defaults_v1.2.8340.362.db")
+
+      prepInputs(
         destinationPath = inputPath(sim),
         url         = extractURL("dbPath"),
-        targetFile  = "cbm_defaults_v1.2.8340.362.db",
-        fun         = NA,
-        purge = 7 ##keep this in as it solves the malformed disc error when running in certain scenarios
+        targetFile  = basename(sim$dbPath),
+        dlFun       = if (!file.exists(sim$dbPath)){
+          download.file(extractURL("dbPath"), sim$dbPath, mode = "wb", quiet = TRUE)
+        },
+        fun = NA
       )
     }
   }
@@ -246,7 +250,7 @@ sim$species_tr <- species_tr[locale_id <= 1,]
           filename1   = "ecozone_shp.zip",
           targetFile  = "ecozones.shp",
           alsoExtract = "similar",
-          fun         = sf::st_read(targetFile, quiet = TRUE)
+          fun         = sf::st_read(targetFile, agr = "constant", quiet = TRUE)
         ),
 
         error = function(e) stop(
@@ -258,8 +262,6 @@ sim$species_tr <- species_tr[locale_id <= 1,]
 
       # Make ecoID field
       sim$ecoLocator <- cbind(ecoID = sim$ecoLocator$ECOZONE, sim$ecoLocator)
-
-      sf::st_agr(sim$ecoLocator) <- "constant"
     }
   }
 
@@ -282,13 +284,11 @@ sim$species_tr <- species_tr[locale_id <= 1,]
         filename1   = "spUnit_Locator.zip",
         targetFile  = "spUnit_Locator.shp",
         alsoExtract = "similar",
-        fun         = sf::st_read(targetFile, quiet = TRUE)
+        fun         = sf::st_read(targetFile, agr = "constant", quiet = TRUE)
       )
 
       # Make spuID field
       sim$spuLocator <- cbind(spuID = sim$spuLocator$spu_id, sim$spuLocator)
-
-      sf::st_agr(sim$spuLocator) <- "constant"
     }
   }
 


### PR DESCRIPTION
A fix for the "database disk image is malformed" database download error.

So far no success fixing the ecozones Shapefile download error using the same method: https://github.com/suz-estella/CBM_defaults/pull/2