### PR TITLE
cTransfers table includes sw_hw

### DIFF
--- a/CBM_defaults.R
+++ b/CBM_defaults.R
@@ -116,7 +116,7 @@ Init <- function(sim) {
 
   # here we want to match sim$dMatrixValue with disturbanceMatrix so that sim$CTransfers has disturbance names.
   # CTransfers will have to be subset to the regions' spatial_unit_id.
-  disturbanceNames <- unique(disturbanceMatrix[,.(disturbance_type_id, disturbance_matrix_id, name, description, spatial_unit_id)])
+  disturbanceNames <- unique(disturbanceMatrix[, .(disturbance_type_id, spatial_unit_id, sw_hw, disturbance_matrix_id, name, description)])
   cTransfers <- sim$dMatrixValue[disturbanceNames, on = .(disturbance_matrix_id = disturbance_matrix_id), allow.cartesian=TRUE]
   sim$cTransfers <- cTransfers
 


### PR DESCRIPTION
Stumbled on this issue giving the CBMutils::cTransfersAlluvial function a try!

In the CBM EXN system, disturbance matrix IDs are unique to each disturbance_type_id, spatial_unit_id, and sw_hw flag. Therefore, this table needs to now also include the sw_hw flag to distinguish unique rows.